### PR TITLE
feat: self-bundle is a permitted resume callback

### DIFF
--- a/Auth0/LoginTransaction.swift
+++ b/Auth0/LoginTransaction.swift
@@ -38,7 +38,11 @@ class LoginTransaction: NSObject, AuthTransaction {
     }
 
     private func handleURL(_ url: URL) -> Bool {
-        guard url.absoluteString.lowercased().hasPrefix(self.redirectURL.absoluteString.lowercased()),
+        let isMatchingURL = url.absoluteString.lowercased().hasPrefix(self.redirectURL.absoluteString.lowercased())
+        let isMatchingBundleID = url.scheme == Bundle.main.bundleIdentifier?.appending(".auth0")
+        
+        guard isMatchingURL || isMatchingBundleID,
+
               let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
               case let items = self.handler.values(fromComponents: components),
               has(state: self.state, inItems: items) else {

--- a/Auth0Tests/LoginTransactionSpec.swift
+++ b/Auth0Tests/LoginTransactionSpec.swift
@@ -8,12 +8,16 @@ class LoginTransactionSpec: QuickSpec {
 
     override func spec() {
         var transaction: LoginTransaction!
-        let userAgent = SpyUserAgent()
-        let handler = SpyGrant()
-        let loggerOutput = SpyOutput()
+        var userAgent: SpyUserAgent!
+        var handler: SpyGrant!
+        var loggerOutput: SpyOutput!
         let code = "123456"
 
         beforeEach {
+            userAgent = SpyUserAgent()
+            handler = SpyGrant()
+            loggerOutput = SpyOutput()
+            
             transaction = LoginTransaction(redirectURL: URL(string: "https://samples.auth0.com/callback")!,
                                            state: "state",
                                            userAgent: userAgent,
@@ -47,6 +51,17 @@ class LoginTransactionSpec: QuickSpec {
                     let expectedError = WebAuthError(code: .unknown("Invalid callback URL: \(url.absoluteString)"))
                     expect(transaction.resume(url)) == false
                     expect(userAgent.result).to(haveWebAuthError(expectedError))
+                    expect(transaction.userAgent).to(beNil())
+                }
+
+                it("should succeed when using bundle schema") {
+                    // NOTE: Interpolated so other schemes can run this test
+                    let bundleId = Bundle.main.bundleIdentifier ?? ""
+                    let url = URL(string: "\(bundleId).auth0://samples.auth0.com/callback?code=\(code)&state=state")!
+                    let items = ["code": code, "state": "state"]
+                    expect(transaction.resume(url)) == true
+                    expect(handler.items) == items
+                    expect(loggerOutput.messages.first).to(contain([url.absoluteString, "Callback URL"]))
                     expect(transaction.userAgent).to(beNil())
                 }
 


### PR DESCRIPTION
When resuming the flow, some urls can be registered by the application (ex. www.my-app.com can be registered to open <My App>), but in some cases a redirect proxy must be used like in the case of B2B2C Auth0 consumers. Such a proxy could redirect directly into the app using the identifier syntax.

In accordance with "Getting Started" documentation which advises the use of "BUNDLE_IDENTIFIER.auth0://" schema urls we conditionally pass a direct and anticipated match.

More simply, if the outgoing redirect is a proxy, incoming redirects could go directly into the app.

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
